### PR TITLE
smbus: The previous commit parsed the block data in decimal instead of  hex. This change parses the pairs of digits in hex.

### DIFF
--- a/smbus_rw.c
+++ b/smbus_rw.c
@@ -109,12 +109,12 @@ ismaxortrailingjunk(const char *arg, char *end, unsigned long ldata)
 }
 
 static int
-parse_uint8(const char *arg, uint8_t *ret)
+parse_uint8_base(const char *arg, uint8_t *ret, int base)
 {
 	unsigned long ldata;
 	char *end;
 
-	ldata = strtoul(arg, &end, 0);
+	ldata = strtoul(arg, &end, base);
 	if (ismaxortrailingjunk(arg, end, ldata))
 		return -1;
 	if (ldata > 0xff) {
@@ -124,6 +124,19 @@ parse_uint8(const char *arg, uint8_t *ret)
 	*ret = (uint8_t)ldata;
 	return 0;
 }
+
+static int
+parse_uint8(const char *arg, uint8_t *ret)
+{
+	return parse_uint8_base(arg, ret, 0);
+}
+
+static int
+parse_uint8_hex(const char *arg, uint8_t *ret)
+{
+	return parse_uint8_base(arg, ret, 16);
+}
+
 
 /* smbus_prologue is responsible for doing the common bits for both smbus read
  * and write. It will parse the comand line arguments and open the appropriate
@@ -313,8 +326,10 @@ parse_io_width(const char *arg, struct smbus_op_params *params,
 		char str_nibble[3];
 
 		len = strlen(arg);
-		if ( (len <= 0) || (len > 64) || (len % 2 != 0) ) {
-			fprintf(stderr, "%d: length is 0 or >64 or odd\n", len);
+		if ((len <= 0) || (len % 2 != 0) ||
+		    (len/2 > I2C_SMBUS_BLOCK_MAX) ) {
+			fprintf(stderr, "%d: length is 0 or >%d or odd\n",
+				len, I2C_SMBUS_BLOCK_MAX);
 			return -1;
 		}
 
@@ -329,9 +344,8 @@ parse_io_width(const char *arg, struct smbus_op_params *params,
 		for (; i < len; i += 2) {
 			str_nibble[0] = arg[i];
 			str_nibble[1] = arg[i+1];
-			assert(i/2 >= 0 && i/2 < sizeof params->data.array);
-			if (parse_uint8(str_nibble, &params->data.array[i/2]))
-				/* parse_uint8 has complained */
+			if (parse_uint8_hex(str_nibble, &params->data.array[i/2]))
+				/* parse_uint8_hex has complained */
 				return -1;
 		}
 		params->len = len / 2;


### PR DESCRIPTION
Signed-off-by: JeanMarc.Eurin@gmail.com